### PR TITLE
Update readthedocs to use new buildCondaDocs script

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,4 @@ build:
   tools:
     python: "mambaforge-22.9"
   commands:
-    - cd doc; ./buildDocs.sh
+    - cd doc;BUILDDIR=$READTHEDOCS_OUTPUT ./buildCondaDocs.sh

--- a/doc/buildDocs.sh
+++ b/doc/buildDocs.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-ZSH_RC_FILE="${HOME}/.bashrc" ../buildCondaLocal.sh
-eval "$(conda shell.bash hook)"
-conda activate bpreveal-teak
-BUILDDIR=${READTHEDOCS_OUTPUT:-"_build"} make html


### PR DESCRIPTION
This PR makes several changes to accommodate automated doc generation via ReadTheDocs

- Removes the obsolete script `buildDocs.sh` and instead updates the new `buildCondaDocs.sh` to also accomplish the building of the docs.
- `buildCondaDocs.sh` is updated to use bash as ReadTheDocs does not support zsh
- The unnecessary sourcing of the ".zshrc" is removed as it is not required for ReadTheDocs automated doc generation, and including it introduces some confusion as it is would then be a bash script sourcing .zshrc, which is contradictory.
- This PR also updates `buildCondaDocs.sh` to slightly modify the `check` function. Instead of using a `check` function after each command, it is updated to use a `runAndCheck` function on each executed command. The updated `runAndCheck` function outputs the upcoming command, runs the command, and outputs the success of the command. In error cases it outputs the line number of the script where the error originated. This output is much more friendly for CI and aids with quick debugging.
- The new `runAndCheck` function now performs `exit 1` instead of `exit` after an error is detected. This allows for CI or other programs to pick up on fail states, instead of assuming the script exited successfully after an error.